### PR TITLE
AEM-129 - one time processes

### DIFF
--- a/core/src/main/java/org/cru/contentscoring/core/service/impl/SyncScoreServiceImpl.java
+++ b/core/src/main/java/org/cru/contentscoring/core/service/impl/SyncScoreServiceImpl.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class SyncScoreServiceImpl implements SyncScoreService {
     private static final Logger LOG = LoggerFactory.getLogger(SyncScoreServiceImpl.class);
 
-    static final String SCALE_OF_BELIEF_TAG_PREFIX = "target-audience:scale-of-belief/";
+    public static final String SCALE_OF_BELIEF_TAG_PREFIX = "target-audience:scale-of-belief/";
 
     @Override
     public void syncScore(

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
@@ -76,9 +76,11 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
         search.addPredicate(buildScorePredicate());
         search.addPredicate(buildTypePredicate());
         search.setSearchIn(root.getPath());
+        search.setHitsPerPage(0L); // 0 means unlimited
 
         try {
             SearchResult searchResult = search.getResult();
+            LOG.debug("Search took {} seconds", searchResult.getExecutionTime());
             return searchResult.getHits();
         } catch (RepositoryException e) {
             LOG.error("Failed to search for pages with a score property under path {}", root.getPath(), e);

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
@@ -74,7 +74,8 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
     private List<Hit> findPagesWithScoreProperty(final Resource root) {
         SimpleSearch search = root.adaptTo(SimpleSearch.class);
         search.addPredicate(buildScorePredicate());
-        search.addPredicate(buildRootPathPredicate(root.getPath()));
+        search.addPredicate(buildTypePredicate());
+        search.setSearchIn(root.getPath());
 
         try {
             SearchResult searchResult = search.getResult();
@@ -92,11 +93,10 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
         return scorePredicate;
     }
 
-    private Predicate buildRootPathPredicate(final String rootPath) {
-        Predicate rootPathPredicate = new Predicate("rootPath", "path");
-        rootPathPredicate.set("path", rootPath);
-        rootPathPredicate.set("self", "true");
-        return rootPathPredicate;
+    private Predicate buildTypePredicate() {
+        Predicate typePredicate = new Predicate("type", "type");
+        typePredicate.set("type", "cq:Page");
+        return typePredicate;
     }
 
     private void moveScoresToTags(final List<Hit> results, final TagManager tagManager) throws RepositoryException {

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
@@ -141,11 +141,9 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
     private void moveScoreToTag(final Resource page, final TagManager tagManager) throws RepositoryException {
         Resource pageContent = getJcrContent(page);
 
-        if (pageContent != null) {
-            String score = pageContent.getValueMap().get("score", String.class);
-            pageContent.adaptTo(Node.class).getProperty("score").remove();
-            setTags(pageContent, tagManager, score);
-        }
+        String score = pageContent.getValueMap().get("score", String.class);
+        pageContent.adaptTo(Node.class).getProperty("score").remove();
+        setTags(pageContent, tagManager, score);
     }
 
     private void copyScoreTagToPrimaryExperienceFragment(
@@ -155,31 +153,29 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
 
         Resource pageContent = getJcrContent(page);
 
-        if (pageContent != null) {
-            String score = pageContent.getValueMap().get("score", String.class);
-            String primaryExperienceFragmentPath = pageContent.getValueMap().get(PRIMARY_XF_NAME, String.class);
+        String score = pageContent.getValueMap().get("score", String.class);
+        String primaryExperienceFragmentPath = pageContent.getValueMap().get(PRIMARY_XF_NAME, String.class);
 
-            if (!Strings.isNullOrEmpty(primaryExperienceFragmentPath)) {
-                Resource primaryExperienceFragment = resourceResolver.getResource(primaryExperienceFragmentPath);
-                Resource experienceFragment;
+        if (!Strings.isNullOrEmpty(primaryExperienceFragmentPath)) {
+            Resource primaryExperienceFragment = resourceResolver.getResource(primaryExperienceFragmentPath);
+            Resource experienceFragment;
 
-                if (primaryExperienceFragment != null) {
-                    if (isExperienceFragmentVariation(primaryExperienceFragment)) {
-                        experienceFragment = primaryExperienceFragment.getParent();
-                    } else if (isExperienceFragment(primaryExperienceFragment)) {
-                        experienceFragment = primaryExperienceFragment;
-                    } else {
-                        return;
-                    }
+            if (primaryExperienceFragment != null) {
+                if (isExperienceFragmentVariation(primaryExperienceFragment)) {
+                    experienceFragment = primaryExperienceFragment.getParent();
+                } else if (isExperienceFragment(primaryExperienceFragment)) {
+                    experienceFragment = primaryExperienceFragment;
+                } else {
+                    return;
+                }
 
-                    Resource experienceFragmentContent = getJcrContent(experienceFragment);
-                    setTags(experienceFragmentContent, tagManager, score);
+                Resource experienceFragmentContent = getJcrContent(experienceFragment);
+                setTags(experienceFragmentContent, tagManager, score);
 
-                    for (Resource child : experienceFragment.getChildren()) {
-                        Resource childContent = getJcrContent(child);
-                        if (childContent != null) {
-                            setTags(childContent, tagManager, score);
-                        }
+                for (Resource child : experienceFragment.getChildren()) {
+                    Resource childContent = getJcrContent(child);
+                    if (childContent != null) {
+                        setTags(childContent, tagManager, score);
                     }
                 }
             }

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
@@ -87,7 +87,7 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
         try {
             moveScoresToTags(results, tagManager, resourceResolver);
         } catch (RepositoryException | ReplicationException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.getMessage(), e);
             response.sendError(500, e.getMessage());
         }
     }

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
@@ -144,9 +144,7 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
         if (pageContent != null) {
             String score = pageContent.getValueMap().get("score", String.class);
             pageContent.adaptTo(Node.class).getProperty("score").remove();
-
-            Set<Tag> tags = buildTagsWithScore(pageContent, tagManager, score);
-            tagManager.setTags(pageContent, tags.toArray(new Tag[0]));
+            setTags(pageContent, tagManager, score);
         }
     }
 
@@ -175,14 +173,12 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
                     }
 
                     Resource experienceFragmentContent = getJcrContent(experienceFragment);
-                    Set<Tag> tags = buildTagsWithScore(experienceFragmentContent, tagManager, score);
-                    tagManager.setTags(experienceFragmentContent, tags.toArray(new Tag[0]));
+                    setTags(experienceFragmentContent, tagManager, score);
 
                     for (Resource child : experienceFragment.getChildren()) {
                         Resource childContent = getJcrContent(child);
                         if (childContent != null) {
-                            Set<Tag> childTags = buildTagsWithScore(childContent, tagManager, score);
-                            tagManager.setTags(childContent, childTags.toArray(new Tag[0]));
+                            setTags(childContent, tagManager, score);
                         }
                     }
                 }
@@ -195,6 +191,11 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
             return resource.getChild(JcrConstants.JCR_CONTENT);
         }
         return null;
+    }
+
+    private void setTags(final Resource jcrContent, final TagManager tagManager, final String score) {
+        Set<Tag> childTags = buildTagsWithScore(jcrContent, tagManager, score);
+        tagManager.setTags(jcrContent, childTags.toArray(new Tag[0]));
     }
 
     private Set<Tag> buildTagsWithScore(

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
@@ -13,6 +13,7 @@ import com.day.cq.tagging.Tag;
 import com.day.cq.tagging.TagManager;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -31,6 +32,7 @@ import java.io.IOException;
 import java.security.Principal;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static org.cru.contentscoring.core.service.impl.SyncScoreServiceImpl.SCALE_OF_BELIEF_TAG_PREFIX;
 
@@ -137,7 +139,7 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
             String score = pageContent.getValueMap().get("score", String.class);
             pageContent.adaptTo(Node.class).getProperty("score").remove();
 
-            List<Tag> tags = buildTagsWithScore(pageContent, tagManager, score);
+            Set<Tag> tags = buildTagsWithScore(pageContent, tagManager, score);
             tagManager.setTags(pageContent, tags.toArray(new Tag[0]));
         }
     }
@@ -149,18 +151,18 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
         return null;
     }
 
-    private List<Tag> buildTagsWithScore(
+    private Set<Tag> buildTagsWithScore(
         final Resource contentResource,
         final TagManager tagManager,
         final String score) {
 
         Tag[] existingTags = tagManager.getTags(contentResource);
-        List<Tag> newTags = Lists.newArrayList();
+        Set<Tag> newTags = Sets.newHashSet();
 
         for (Tag existingTag : existingTags) {
             // If there is already a score tag on this resource, prefer it over the property.
             if (existingTag.getTagID().startsWith(SCALE_OF_BELIEF_TAG_PREFIX)) {
-                return Arrays.asList(existingTags);
+                return Sets.newHashSet(Arrays.asList(existingTags));
             }
             newTags.add(existingTag);
         }

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
@@ -187,6 +187,10 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
                 }
             }
 
+            if (pathsToReplicate.isEmpty()) {
+                return;
+            }
+
             replicator.replicate(
                 session,
                 ReplicationActionType.ACTIVATE,

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
@@ -1,0 +1,147 @@
+package org.cru.contentscoring.core.servlets;
+
+import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.search.Predicate;
+import com.day.cq.search.SimpleSearch;
+import com.day.cq.search.result.Hit;
+import com.day.cq.search.result.SearchResult;
+import com.day.cq.tagging.Tag;
+import com.day.cq.tagging.TagManager;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import org.apache.felix.scr.annotations.sling.SlingServlet;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.RepositoryException;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.cru.contentscoring.core.service.impl.SyncScoreServiceImpl.SCALE_OF_BELIEF_TAG_PREFIX;
+
+@SlingServlet(
+    paths = "/bin/cru/content-scoring/move-scores-to-tags",
+    metatype = true,
+    methods = {"PUT"}
+)
+public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
+    private static final Logger LOG = LoggerFactory.getLogger(CopyScoresToTagsServlet.class);
+
+    @Override
+    protected void doPut(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
+        throws IOException {
+
+        String path = request.getParameter("path");
+        if (Strings.isNullOrEmpty(path)) {
+            response.sendError(400, "Path is required");
+            return;
+        }
+
+        Principal principal = request.getUserPrincipal();
+        if (principal == null || !principal.getName().equals("admin")) {
+            LOG.error(
+                "Unauthorized attempt to move scores to tags by {}",
+                principal == null ? "Anonymous" : principal.getName());
+            response.sendError(401, "You are not authorized to perform this command.");
+            return;
+        }
+
+        Resource root = request.getResourceResolver().getResource(path);
+        if (root == null) {
+            response.sendError(400, "Invalid path");
+            return;
+        }
+
+        TagManager tagManager = request.getResourceResolver().adaptTo(TagManager.class);
+
+        List<Hit> results = findPagesWithScoreProperty(root);
+
+        try {
+            copyScoresToTags(results, tagManager);
+        } catch (RepositoryException e) {
+            LOG.error(e.getMessage());
+            response.sendError(500, e.getMessage());
+        }
+    }
+
+    private List<Hit> findPagesWithScoreProperty(final Resource root) {
+        SimpleSearch search = root.adaptTo(SimpleSearch.class);
+        search.addPredicate(buildScorePredicate());
+        search.addPredicate(buildRootPathPredicate(root.getPath()));
+
+        try {
+            SearchResult searchResult = search.getResult();
+            return searchResult.getHits();
+        } catch (RepositoryException e) {
+            LOG.error("Failed to search for pages with a score property under path {}", root.getPath(), e);
+        }
+        return Lists.newArrayList();
+    }
+
+    private Predicate buildScorePredicate() {
+        Predicate scorePredicate = new Predicate("score", "property");
+        scorePredicate.set("property", JcrConstants.JCR_CONTENT + "/" + "score");
+        scorePredicate.set("operation", "exists");
+        return scorePredicate;
+    }
+
+    private Predicate buildRootPathPredicate(final String rootPath) {
+        Predicate rootPathPredicate = new Predicate("rootPath", "path");
+        rootPathPredicate.set("path", rootPath);
+        rootPathPredicate.set("self", "true");
+        return rootPathPredicate;
+    }
+
+    private void copyScoresToTags(final List<Hit> results, final TagManager tagManager) throws RepositoryException {
+        for (Hit result : results) {
+            copyScoreToTag(result.getResource(), tagManager);
+        }
+    }
+
+    private void copyScoreToTag(final Resource page, final TagManager tagManager) {
+        Resource pageContent = getJcrContent(page);
+
+        if (pageContent != null) {
+            String score = pageContent.getValueMap().get("score", String.class);
+            List<Tag> tags = buildTagsWithScore(pageContent, tagManager, score);
+            tagManager.setTags(pageContent, tags.toArray(new Tag[0]));
+        }
+    }
+
+    private Resource getJcrContent(final Resource resource) {
+        if (resource != null && resource.getResourceType().equals("cq:Page")) {
+            return resource.getChild(JcrConstants.JCR_CONTENT);
+        }
+        return null;
+    }
+
+    private List<Tag> buildTagsWithScore(
+        final Resource contentResource,
+        final TagManager tagManager,
+        final String score) {
+
+        Tag[] existingTags = tagManager.getTags(contentResource);
+        List<Tag> newTags = Lists.newArrayList();
+
+        for (Tag existingTag : existingTags) {
+            // If there is already a score tag on this resource, prefer it over the property.
+            if (existingTag.getTagID().startsWith(SCALE_OF_BELIEF_TAG_PREFIX)) {
+                return Arrays.asList(existingTags);
+            }
+            newTags.add(existingTag);
+        }
+
+        Tag scoreTag = tagManager.resolve(SCALE_OF_BELIEF_TAG_PREFIX + score);
+        if (scoreTag != null) {
+            newTags.add(scoreTag);
+        }
+
+        return newTags;
+    }
+}

--- a/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -3,7 +3,4 @@
     <filter root="/apps/aem-content-scoring">
         <exclude pattern="/apps/aem-content-scoring/install" />
     </filter>
-    <filter root="/etc/designs/aem-content-scoring"/>
-    <filter root="/etc/workflow/launcher/config/aem-content-scoring"/>
-    <filter root="/etc/workflow/models/aem-content-scoring"/>
 </workspaceFilter>


### PR DESCRIPTION
This PR creates a servlet that can be used as a one time process to move scores to tags. This servlet can only be used by the admin user. We can delete this code once the process has been run in UAT and production.

As part of this, I will manually create an oak index to help traverse the nodes.

This builds on #6 