### PR TITLE
AEM-129 - Stop saving score property

### DIFF
--- a/core/src/main/java/org/cru/contentscoring/core/service/impl/SyncScoreServiceImpl.java
+++ b/core/src/main/java/org/cru/contentscoring/core/service/impl/SyncScoreServiceImpl.java
@@ -48,7 +48,6 @@ public class SyncScoreServiceImpl implements SyncScoreService {
             Node node = contentResource.adaptTo(Node.class);
             if (node != null) {
                 LOG.debug("Setting score on {} to {}", node.getPath(), score);
-                node.setProperty("score", Integer.toString(score));
 
                 Calendar now = Calendar.getInstance();
 

--- a/core/src/test/java/org/cru/contentscoring/core/service/impl/SyncScoreServiceImplTest.java
+++ b/core/src/test/java/org/cru/contentscoring/core/service/impl/SyncScoreServiceImplTest.java
@@ -153,7 +153,6 @@ public class SyncScoreServiceImplTest {
     }
 
     private void assertSuccessful(final Map<String, Object> propertyMap, final Tag[] tags) {
-        assertThat(propertyMap.get("score"), is(equalTo(Integer.toString(SCORE))));
         assertThat(propertyMap.get("cq:lastModifiedBy"), is(equalTo("scale-of-belief")));
         assertThat(propertyMap.get("cq:lastModified"), is(notNullValue()));
         assertThat(propertyMap.get("contentScoreLastUpdated"), is(notNullValue()));


### PR DESCRIPTION
Now that we aren't allowing authors to save the content score as a separate property, we can stop having the sync save the property as well. Commit a076e29 should have probably been part of #6 but I forgot to do it there.