### PR TITLE
RB-10 - Skip experience fragments

### DIFF
--- a/core/src/main/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImpl.java
+++ b/core/src/main/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImpl.java
@@ -15,11 +15,13 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.commons.osgi.PropertiesUtil;
 import org.cru.contentscoring.core.models.ContentScoreUpdateRequest;
 import org.cru.contentscoring.core.queue.UploadQueue;
 import org.cru.contentscoring.core.service.ContentScoreUpdateService;
+import org.cru.contentscoring.core.util.ExperienceFragmentUtil;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -160,6 +162,12 @@ public class ContentScoreUpdateServiceImpl implements ContentScoreUpdateService 
 
     @Override
     public void updateContentScore(final Page page) throws RepositoryException {
+        Resource jcrContent = page.getContentResource();
+        if (ExperienceFragmentUtil.isExperienceFragment(jcrContent)
+            || ExperienceFragmentUtil.isExperienceFragmentVariation(jcrContent)) {
+            return;
+        }
+
         int score = getScore(page);
         if (score == -1) {
             return;

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/CopyScoresToTagsServlet.java
@@ -20,6 +20,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.settings.SlingSettingsService;
+import org.cru.contentscoring.core.util.ExperienceFragmentUtil;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -47,8 +48,6 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
     private static final Logger LOG = LoggerFactory.getLogger(CopyScoresToTagsServlet.class);
 
     private static final String PRIMARY_XF_NAME = "primaryExperienceFragment";
-    private static final String XF_TYPE = "cq/experience-fragments/components/experiencefragment";
-    private static final String XF_VARIANT_TYPE = "cq:xfVariantType";
 
     @Reference
     private SlingSettingsService slingSettingsService;
@@ -163,9 +162,10 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
             Resource experienceFragment;
 
             if (primaryExperienceFragment != null) {
-                if (isExperienceFragmentVariation(primaryExperienceFragment)) {
+                Resource jcrContent = getJcrContent(primaryExperienceFragment);
+                if (ExperienceFragmentUtil.isExperienceFragmentVariation(jcrContent)) {
                     experienceFragment = primaryExperienceFragment.getParent();
-                } else if (isExperienceFragment(primaryExperienceFragment)) {
+                } else if (ExperienceFragmentUtil.isExperienceFragment(jcrContent)) {
                     experienceFragment = primaryExperienceFragment;
                 } else {
                     return;
@@ -244,15 +244,5 @@ public class CopyScoresToTagsServlet extends SlingAllMethodsServlet {
                 pathsToReplicate.toArray(new String[]{}),
                 new ReplicationOptions());
         }
-    }
-
-    private boolean isExperienceFragment(final Resource resource) {
-        Resource jcrContent = getJcrContent(resource);
-        return jcrContent != null && jcrContent.getResourceType().equals(XF_TYPE);
-    }
-
-    private boolean isExperienceFragmentVariation(final Resource resource) {
-        Resource jcrContent = getJcrContent(resource);
-        return jcrContent != null && jcrContent.getValueMap().containsKey(XF_VARIANT_TYPE);
     }
 }

--- a/core/src/main/java/org/cru/contentscoring/core/util/ExperienceFragmentUtil.java
+++ b/core/src/main/java/org/cru/contentscoring/core/util/ExperienceFragmentUtil.java
@@ -1,0 +1,18 @@
+package org.cru.contentscoring.core.util;
+
+import org.apache.sling.api.resource.Resource;
+
+public class ExperienceFragmentUtil {
+    private static final String XF_TYPE = "cq/experience-fragments/components/experiencefragment";
+    private static final String XF_VARIANT_TYPE = "cq:xfVariantType";
+
+    private ExperienceFragmentUtil() {}
+
+    public static boolean isExperienceFragment(final Resource jcrContent) {
+        return jcrContent != null && jcrContent.getResourceType().equals(XF_TYPE);
+    }
+
+    public static boolean isExperienceFragmentVariation(final Resource jcrContent) {
+        return jcrContent != null && jcrContent.getValueMap().containsKey(XF_VARIANT_TYPE);
+    }
+}

--- a/core/src/main/java/org/cru/contentscoring/core/util/ExperienceFragmentUtil.java
+++ b/core/src/main/java/org/cru/contentscoring/core/util/ExperienceFragmentUtil.java
@@ -3,8 +3,8 @@ package org.cru.contentscoring.core.util;
 import org.apache.sling.api.resource.Resource;
 
 public class ExperienceFragmentUtil {
-    private static final String XF_TYPE = "cq/experience-fragments/components/experiencefragment";
-    private static final String XF_VARIANT_TYPE = "cq:xfVariantType";
+    public static final String XF_TYPE = "cq/experience-fragments/components/experiencefragment";
+    public static final String XF_VARIANT_TYPE = "cq:xfVariantType";
 
     private ExperienceFragmentUtil() {}
 

--- a/core/src/test/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImplTest.java
+++ b/core/src/test/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImplTest.java
@@ -13,6 +13,7 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.cru.contentscoring.core.models.ContentScoreUpdateRequest;
 import org.cru.contentscoring.core.queue.UploadQueue;
+import org.cru.contentscoring.core.util.ExperienceFragmentUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,6 +58,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -80,11 +82,14 @@ public class ContentScoreUpdateServiceImplTest {
     @InjectMocks
     private ContentScoreUpdateServiceImpl updateService;
 
+    private Session session;
+
     @Before
     public void setup() throws Exception {
         String site = "https://page.com";
         String pagePath = "/content/test/us/en/page-path";
         page = mockPage(site, pagePath, pagePath, site + pagePath);
+        session = mock(Session.class);
     }
 
     @Test
@@ -326,6 +331,32 @@ public class ContentScoreUpdateServiceImplTest {
         assertThat(request.getUri(), is(equalTo(site + pagePath + HTML_EXTENSION)));
     }
 
+    @Test
+    public void testExperienceFragment() throws Exception {
+        String xfPath = "/content/experience-fragments/shared/en/path";
+
+        Page page = mockPage(null, xfPath, null, null);
+        Resource jcrContent = page.getContentResource();
+        when(jcrContent.getResourceType()).thenReturn(ExperienceFragmentUtil.XF_TYPE);
+
+        updateService.updateContentScore(page);
+        verify(session, never()).save();
+    }
+
+    @Test
+    public void testExperienceFragmentVariation() throws Exception {
+        String path = "/content/experience-fragments/shared/en/path/variation";
+
+        Page page = mockPage(null, path, null, null);
+        Resource jcrContent = page.getContentResource();
+        when(jcrContent.getResourceType()).thenReturn("Site/components/structure/xfpage");
+        Map<String, Object> properties = jcrContent.getValueMap();
+        properties.put(ExperienceFragmentUtil.XF_VARIANT_TYPE, "web");
+
+        updateService.updateContentScore(page);
+        verify(session, never()).save();
+    }
+
     private void initializeQueue() {
         ContentScoreUpdateServiceImpl.internalQueueManager = new UploadQueue(
             2 * 60 * 1000L,
@@ -383,7 +414,6 @@ public class ContentScoreUpdateServiceImplTest {
         when(contentResource.getResourceType()).thenReturn("/Site/components/page/page");
         when(contentResource.getValueMap()).thenReturn(new ValueMapDecorator(properties));
 
-        Session session = mock(Session.class);
         when(contentNode.getSession()).thenReturn(session);
         when(page.getContentResource()).thenReturn(contentResource);
 

--- a/core/src/test/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImplTest.java
+++ b/core/src/test/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImplTest.java
@@ -375,9 +375,14 @@ public class ContentScoreUpdateServiceImplTest {
         Resource resource = mock(Resource.class);
         when(page.adaptTo(Resource.class)).thenReturn(resource);
 
+        Map<String, Object> properties = new HashMap<>();
+
         Resource contentResource = mock(Resource.class);
         Node contentNode = mock(Node.class);
         when(contentResource.adaptTo(Node.class)).thenReturn(contentNode);
+        when(contentResource.getResourceType()).thenReturn("/Site/components/page/page");
+        when(contentResource.getValueMap()).thenReturn(new ValueMapDecorator(properties));
+
         Session session = mock(Session.class);
         when(contentNode.getSession()).thenReturn(session);
         when(page.getContentResource()).thenReturn(contentResource);


### PR DESCRIPTION
This PR seeks to fix another instance of issues found in [Rollbar #10](https://rollbar.com/Cru/cru-aem-content-scoring/items/10/) where experience fragments were being sent to the API. Experience fragments are used in many contexts, and thus should not be sent to the content scoring API. Instead, the page(s) that use the experience fragment should send the score to the API when it is published. Because of the code tying the two together, this should be happening mostly automatically.

This was an issue because experience fragments are technically pages, so when they have a score on them and are replicated, they come through this code.