### PR TITLE
RB-26 - Fix NPE

### DIFF
--- a/core/src/main/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImpl.java
+++ b/core/src/main/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImpl.java
@@ -96,7 +96,7 @@ public class ContentScoreUpdateServiceImpl implements ContentScoreUpdateService 
     private UUID apiKey;
     private String urlMapperEndpoint;
 
-    ClientBuilder clientBuilder;
+    Client client;
 
 
     @Reference
@@ -118,7 +118,7 @@ public class ContentScoreUpdateServiceImpl implements ContentScoreUpdateService 
         Preconditions.checkNotNull(urlMapperEndpoint, "URL Mapper Endpoint must be configured in aem_osgi_config.");
 
         startQueueManager(config);
-        clientBuilder = ClientBuilder.newBuilder();
+        client = ClientBuilder.newBuilder().build().register(JacksonJsonProvider.class);
     }
 
     private void startQueueManager(final Map<String, Object> config) {
@@ -226,7 +226,6 @@ public class ContentScoreUpdateServiceImpl implements ContentScoreUpdateService 
     }
 
     private Set<String> getUrlsFromPaths(final Set<String> paths) {
-        Client client = clientBuilder.register(JacksonJsonProvider.class).build();
         WebTarget webTarget = client.target(urlMapperEndpoint);
 
         for (String path : paths) {

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServlet.java
@@ -97,7 +97,10 @@ public class ResourceUrlMapperServlet extends SlingSafeMethodsServlet {
         for (String path : paths) {
             Resource resource = resourceResolver.getResource(path);
             if (resource != null) {
-                urls.add(absolutePathUriProvider.toURI(resource, Scope.EXTERNAL, Operation.READ).toString());
+                URI absoluteUri = absolutePathUriProvider.toURI(resource, Scope.EXTERNAL, Operation.READ);
+                if (absoluteUri != null) {
+                    urls.add(absoluteUri.toString());
+                }
             } else {
                 resource = resourceResolver.resolve(path);
                 if (resource instanceof NonExistingResource) {

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServlet.java
@@ -1,6 +1,7 @@
 package org.cru.contentscoring.core.servlets;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -103,7 +104,10 @@ public class ResourceUrlMapperServlet extends SlingSafeMethodsServlet {
                     continue;
                 }
                 // This means that a resource exists that can be mapped by the given vanity URL
-                urls.add(vanityPathUriProvider.toURI(path, resourceResolver).toString());
+                URI vanityUri = vanityPathUriProvider.toURI(path, resourceResolver);
+                if (vanityUri != null) {
+                    urls.add(vanityUri.toString());
+                }
             }
         }
 

--- a/core/src/test/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImplTest.java
+++ b/core/src/test/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImplTest.java
@@ -76,9 +76,8 @@ public class ContentScoreUpdateServiceImplTest {
 
     @Before
     public void setup() throws Exception {
-        String site = "https://page.com";
         String pagePath = "/content/test/us/en/page-path";
-        page = mockPage(site, pagePath, pagePath, site + pagePath);
+        page = mockPage(pagePath);
         session = mock(Session.class);
     }
 
@@ -165,7 +164,7 @@ public class ContentScoreUpdateServiceImplTest {
     public void testDeterminePageUrlsToSendNoVanities() throws Exception {
         String site = "https://page.com";
         String pagePath = "/content/test/us/en/page-path";
-        Page page = mockPage(site, pagePath, pagePath, site + pagePath);
+        Page page = mockPage(pagePath);
 
         mockResponse(Sets.newHashSet(site + pagePath + HTML_EXTENSION));
 
@@ -180,7 +179,7 @@ public class ContentScoreUpdateServiceImplTest {
         String vanityPath = "/vanity-url";
         String pagePath = "/content/test/us/en/page-path";
 
-        Page page = mockPage(site, pagePath, vanityPath, site + vanityPath);
+        Page page = mockPage(pagePath);
         when(page.getVanityUrl()).thenReturn(vanityPath);
 
         Map<String, Object> properties = new HashMap<>();
@@ -204,7 +203,7 @@ public class ContentScoreUpdateServiceImplTest {
         String vanityPath = "/vanity-url";
         String pagePath = "/content/test/us/en/page-path";
 
-        Page page = mockPage(site, pagePath, vanityPath, site + vanityPath);
+        Page page = mockPage(pagePath);
         when(page.getVanityUrl()).thenReturn(vanityPath);
 
         Map<String, Object> properties = new HashMap<>();
@@ -229,7 +228,7 @@ public class ContentScoreUpdateServiceImplTest {
         String secondVanity = "/content/test/us/en/vanity-url";
         String pagePath = "/content/test/us/en/page-path";
 
-        Page page = mockPage(site, pagePath, vanityPath, site + vanityPath);
+        Page page = mockPage(pagePath);
         when(page.getVanityUrl()).thenReturn(vanityPath);
 
         Map<String, Object> properties = new HashMap<>();
@@ -255,7 +254,7 @@ public class ContentScoreUpdateServiceImplTest {
         String vanityPath = "/vanity-url";
         String pagePath = "/content/test/us/en/page-path";
 
-        Page page = mockPage(site, pagePath, vanityPath, site + vanityPath);
+        Page page = mockPage(pagePath);
         when(page.getVanityUrl()).thenReturn(vanityPath);
 
         Map<String, Object> properties = new HashMap<>();
@@ -291,7 +290,7 @@ public class ContentScoreUpdateServiceImplTest {
         String pagePath = "/content/test/us/en/page-path";
         String site = "https://page.com";
 
-        Page page = mockPage(site, pagePath, pagePath, site + pagePath);
+        Page page = mockPage(pagePath);
 
         mockResponse(Sets.newHashSet(site + pagePath + HTML_EXTENSION));
 
@@ -307,7 +306,7 @@ public class ContentScoreUpdateServiceImplTest {
     public void testExperienceFragment() throws Exception {
         String xfPath = "/content/experience-fragments/shared/en/path";
 
-        Page page = mockPage(null, xfPath, null, null);
+        Page page = mockPage(xfPath);
         Resource jcrContent = page.getContentResource();
         when(jcrContent.getResourceType()).thenReturn(ExperienceFragmentUtil.XF_TYPE);
 
@@ -319,7 +318,7 @@ public class ContentScoreUpdateServiceImplTest {
     public void testExperienceFragmentVariation() throws Exception {
         String path = "/content/experience-fragments/shared/en/path/variation";
 
-        Page page = mockPage(null, path, null, null);
+        Page page = mockPage(path);
         Resource jcrContent = page.getContentResource();
         when(jcrContent.getResourceType()).thenReturn("Site/components/structure/xfpage");
         Map<String, Object> properties = jcrContent.getValueMap();
@@ -362,12 +361,7 @@ public class ContentScoreUpdateServiceImplTest {
         updateService.client = client;
     }
 
-    private Page mockPage(
-        final String site,
-        final String pagePath,
-        final String externalizerPath,
-        final String externalLink) throws Exception {
-
+    private Page mockPage(final String pagePath) throws Exception {
         Page page = mock(Page.class);
         when(page.getPath()).thenReturn(pagePath);
 

--- a/core/src/test/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImplTest.java
+++ b/core/src/test/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImplTest.java
@@ -23,7 +23,6 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
@@ -360,10 +359,7 @@ public class ContentScoreUpdateServiceImplTest {
         Client client = mock(Client.class);
         when(client.target(anyString())).thenReturn(webTarget);
 
-        ClientBuilder clientBuilder = mock(ClientBuilder.class);
-        when(clientBuilder.register(any())).thenReturn(clientBuilder);
-        when(clientBuilder.build()).thenReturn(client);
-        updateService.clientBuilder = clientBuilder;
+        updateService.client = client;
     }
 
     private Page mockPage(


### PR DESCRIPTION
Fixes a null pointer on incoming invalid vanity paths. Also added some cleanup things. This exception was causing a 500 HTML response from the servlet, which is why the client could not parse the response.

[Rollbar issue](https://rollbar.com/Cru/cru-aem-content-scoring/items/26/)