### PR TITLE
AEM-187 - Update cru-aem-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -450,15 +450,9 @@
             <dependency>
                 <groupId>org.cru</groupId>
                 <artifactId>aem-bom</artifactId>
-                <version>1.3</version>
+                <version>1.4</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.cru</groupId>
-                <artifactId>cru-aem-commons.core</artifactId>
-                <version>1.3.2</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -455,12 +455,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>1.2.3</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
                 <version>1.1</version>


### PR DESCRIPTION
This bumps the version of `aem-bom`, which now contains the newest version of `cru-aem-commons` to use the asynchronous Rollbar logging as well as the version of `logback` that we are using.

[Jira](https://jira.cru.org/browse/AEM-187)