### PR TITLE
Fix score sync

### DIFF
--- a/core/src/main/java/org/cru/contentscoring/core/provider/AbsolutePathUriProvider.java
+++ b/core/src/main/java/org/cru/contentscoring/core/provider/AbsolutePathUriProvider.java
@@ -25,7 +25,6 @@ public class AbsolutePathUriProvider {
         Resource slingMap = util.determineSlingMap(path, resourceResolver);
 
         if (slingMap != null) {
-            LOG.debug("Found a sling map");
             String protocol = Objects.requireNonNull(slingMap.getParent()).getName();
             String domain = slingMap.getName();
 

--- a/core/src/main/java/org/cru/contentscoring/core/provider/AbsolutePathUriProvider.java
+++ b/core/src/main/java/org/cru/contentscoring/core/provider/AbsolutePathUriProvider.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 public class AbsolutePathUriProvider {
     private static final Logger LOG = LoggerFactory.getLogger(AbsolutePathUriProvider.class);
 
-    private String environment;
+    private final String environment;
 
     public AbsolutePathUriProvider(final String environment) {
         this.environment = environment;

--- a/core/src/main/java/org/cru/contentscoring/core/provider/AbsolutePathUriProvider.java
+++ b/core/src/main/java/org/cru/contentscoring/core/provider/AbsolutePathUriProvider.java
@@ -1,11 +1,8 @@
 package org.cru.contentscoring.core.provider;
 
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.external.URIProvider;
-import org.cru.contentscoring.core.util.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,43 +10,34 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
 
-public class AbsolutePathUriProvider implements URIProvider {
+public class AbsolutePathUriProvider {
     private static final Logger LOG = LoggerFactory.getLogger(AbsolutePathUriProvider.class);
 
-    private static final String SUBSERVICE = "contentScoreSync";
-
     private String environment;
-    private SystemUtils systemUtils;
 
-    public AbsolutePathUriProvider(final String environment, final SystemUtils systemUtils) {
+    public AbsolutePathUriProvider(final String environment) {
         this.environment = environment;
-        this.systemUtils = systemUtils;
     }
 
-    @Override
-    public URI toURI(final Resource resource, final Scope scope, final Operation operation) {
+    public URI toURI(final Resource resource, final ResourceResolver resourceResolver) {
         String path = resource.getPath();
-        try (ResourceResolver resourceResolver = systemUtils.getResourceResolver(SUBSERVICE)) {
-            UriProviderUtil util = UriProviderUtil.getInstance(environment);
-            Resource slingMap = util.determineSlingMap(path, resourceResolver);
+        UriProviderUtil util = UriProviderUtil.getInstance(environment);
+        Resource slingMap = util.determineSlingMap(path, resourceResolver);
 
-            if (slingMap != null) {
-                LOG.debug("Found a sling map");
-                String protocol = Objects.requireNonNull(slingMap.getParent()).getName();
-                String domain = slingMap.getName();
+        if (slingMap != null) {
+            LOG.debug("Found a sling map");
+            String protocol = Objects.requireNonNull(slingMap.getParent()).getName();
+            String domain = slingMap.getName();
 
-                try {
-                    return new URIBuilder()
-                        .setScheme(protocol)
-                        .setHost(domain)
-                        .setPath(path + ".html")
-                        .build();
-                } catch (URISyntaxException e) {
-                    LOG.error("Bad URI", e);
-                }
+            try {
+                return new URIBuilder()
+                    .setScheme(protocol)
+                    .setHost(domain)
+                    .setPath(path + ".html")
+                    .build();
+            } catch (URISyntaxException e) {
+                LOG.error("Bad URI", e);
             }
-        } catch (LoginException e) {
-            LOG.error("Failed to get resource resolver for {}", SUBSERVICE);
         }
 
         return null;

--- a/core/src/main/java/org/cru/contentscoring/core/provider/VanityPathUriProvider.java
+++ b/core/src/main/java/org/cru/contentscoring/core/provider/VanityPathUriProvider.java
@@ -1,11 +1,8 @@
 package org.cru.contentscoring.core.provider;
 
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.external.URIProvider;
-import org.cru.contentscoring.core.util.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,27 +10,13 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
 
-public class VanityPathUriProvider implements URIProvider {
+public class VanityPathUriProvider {
     private static final Logger LOG = LoggerFactory.getLogger(VanityPathUriProvider.class);
 
-    private static final String SUBSERVICE = "contentScoreSync";
-
     private String environment;
-    private final SystemUtils systemUtils;
 
-    public VanityPathUriProvider(final String environment, final SystemUtils systemUtils) {
+    public VanityPathUriProvider(final String environment) {
         this.environment = environment;
-        this.systemUtils = systemUtils;
-    }
-
-    @Override
-    public URI toURI(final Resource resource, final Scope scope, final Operation operation) {
-        try (ResourceResolver resourceResolver = systemUtils.getResourceResolver(SUBSERVICE)) {
-            return toURI(resource.getPath(), resourceResolver);
-        } catch (LoginException e) {
-            LOG.error("Failed to get resource resolver for {}", SUBSERVICE);
-        }
-        return null;
     }
 
     public URI toURI(final String path, final ResourceResolver resourceResolver) {

--- a/core/src/main/java/org/cru/contentscoring/core/provider/VanityPathUriProvider.java
+++ b/core/src/main/java/org/cru/contentscoring/core/provider/VanityPathUriProvider.java
@@ -1,9 +1,11 @@
 package org.cru.contentscoring.core.provider;
 
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.external.URIProvider;
+import org.cru.contentscoring.core.util.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,15 +16,24 @@ import java.util.Objects;
 public class VanityPathUriProvider implements URIProvider {
     private static final Logger LOG = LoggerFactory.getLogger(VanityPathUriProvider.class);
 
-    private String environment;
+    private static final String SUBSERVICE = "contentScoreSync";
 
-    public VanityPathUriProvider(final String environment) {
+    private String environment;
+    private final SystemUtils systemUtils;
+
+    public VanityPathUriProvider(final String environment, final SystemUtils systemUtils) {
         this.environment = environment;
+        this.systemUtils = systemUtils;
     }
 
     @Override
     public URI toURI(final Resource resource, final Scope scope, final Operation operation) {
-        return toURI(resource.getPath(), resource.getResourceResolver());
+        try (ResourceResolver resourceResolver = systemUtils.getResourceResolver(SUBSERVICE)) {
+            return toURI(resource.getPath(), resourceResolver);
+        } catch (LoginException e) {
+            LOG.error("Failed to get resource resolver for {}", SUBSERVICE);
+        }
+        return null;
     }
 
     public URI toURI(final String path, final ResourceResolver resourceResolver) {

--- a/core/src/main/java/org/cru/contentscoring/core/provider/VanityPathUriProvider.java
+++ b/core/src/main/java/org/cru/contentscoring/core/provider/VanityPathUriProvider.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 public class VanityPathUriProvider {
     private static final Logger LOG = LoggerFactory.getLogger(VanityPathUriProvider.class);
 
-    private String environment;
+    private final String environment;
 
     public VanityPathUriProvider(final String environment) {
         this.environment = environment;

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServlet.java
@@ -18,9 +18,6 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.NonExistingResource;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.external.URIProvider;
-import org.apache.sling.api.resource.external.URIProvider.Scope;
-import org.apache.sling.api.resource.external.URIProvider.Operation;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.apache.sling.settings.SlingSettingsService;
@@ -48,7 +45,7 @@ public class ResourceUrlMapperServlet extends SlingSafeMethodsServlet {
 
     private static final String SUBSERVICE = "contentScoreSync";
 
-    URIProvider absolutePathUriProvider;
+    AbsolutePathUriProvider absolutePathUriProvider;
     VanityPathUriProvider vanityPathUriProvider;
 
     @Reference
@@ -62,10 +59,10 @@ public class ResourceUrlMapperServlet extends SlingSafeMethodsServlet {
         String environment = determineEnvironment();
 
         if (absolutePathUriProvider == null) {
-            absolutePathUriProvider = new AbsolutePathUriProvider(environment, systemUtils);
+            absolutePathUriProvider = new AbsolutePathUriProvider(environment);
         }
         if (vanityPathUriProvider == null) {
-            vanityPathUriProvider = new VanityPathUriProvider(environment, systemUtils);
+            vanityPathUriProvider = new VanityPathUriProvider(environment);
         }
     }
 
@@ -114,7 +111,7 @@ public class ResourceUrlMapperServlet extends SlingSafeMethodsServlet {
         for (String path : paths) {
             Resource resource = resourceResolver.getResource(path);
             if (resource != null) {
-                URI absoluteUri = absolutePathUriProvider.toURI(resource, Scope.EXTERNAL, Operation.READ);
+                URI absoluteUri = absolutePathUriProvider.toURI(resource, resourceResolver);
                 if (absoluteUri != null) {
                     urls.add(absoluteUri.toString());
                 }

--- a/core/src/main/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServlet.java
+++ b/core/src/main/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServlet.java
@@ -37,7 +37,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(service = Servlet.class, property = {
         "sling.servlet.methods=" + HttpConstants.METHOD_GET,
-        "sling.servlet.paths=/bin/cru/url/mapper" })
+        "sling.servlet.paths=/bin/cru/url/mapper",
+        "sling.servlet.extensions=txt"})
 public class ResourceUrlMapperServlet extends SlingSafeMethodsServlet {
     URIProvider absolutePathUriProvider;
     VanityPathUriProvider vanityPathUriProvider;

--- a/core/src/test/java/org/cru/contentscoring/core/provider/AbsolutePathUriProviderTest.java
+++ b/core/src/test/java/org/cru/contentscoring/core/provider/AbsolutePathUriProviderTest.java
@@ -4,10 +4,7 @@ import com.google.common.collect.Lists;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.api.resource.external.URIProvider;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
-import org.cru.contentscoring.core.util.SystemUtils;
-import org.cru.contentscoring.core.util.SystemUtilsImpl;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,7 +16,6 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,11 +24,9 @@ public class AbsolutePathUriProviderTest {
     private ResourceResolver resourceResolver;
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
         resourceResolver = mock(ResourceResolver.class);
-        SystemUtils mockSystemUtils = mock(SystemUtils.class);
-        when(mockSystemUtils.getResourceResolver(anyString())).thenReturn(resourceResolver);
-        absolutePathUriProvider = new AbsolutePathUriProvider("local", mockSystemUtils);
+        absolutePathUriProvider = new AbsolutePathUriProvider("local");
     }
 
     @Test
@@ -41,7 +35,7 @@ public class AbsolutePathUriProviderTest {
         when(resource.getResourceResolver()).thenReturn(resourceResolver);
         mockSlingMaps();
 
-        URI uri = absolutePathUriProvider.toURI(resource, URIProvider.Scope.EXTERNAL, URIProvider.Operation.READ);
+        URI uri = absolutePathUriProvider.toURI(resource, resourceResolver);
 
         assertThat(uri.toString(), is(equalTo("https://primary.site.org/content/primary/us/en/wherever.html")));
     }

--- a/core/src/test/java/org/cru/contentscoring/core/provider/AbsolutePathUriProviderTest.java
+++ b/core/src/test/java/org/cru/contentscoring/core/provider/AbsolutePathUriProviderTest.java
@@ -6,6 +6,8 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.resource.external.URIProvider;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.cru.contentscoring.core.util.SystemUtils;
+import org.cru.contentscoring.core.util.SystemUtilsImpl;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -17,6 +19,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,9 +28,11 @@ public class AbsolutePathUriProviderTest {
     private ResourceResolver resourceResolver;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         resourceResolver = mock(ResourceResolver.class);
-        absolutePathUriProvider = new AbsolutePathUriProvider("local");
+        SystemUtils mockSystemUtils = mock(SystemUtils.class);
+        when(mockSystemUtils.getResourceResolver(anyString())).thenReturn(resourceResolver);
+        absolutePathUriProvider = new AbsolutePathUriProvider("local", mockSystemUtils);
     }
 
     @Test

--- a/core/src/test/java/org/cru/contentscoring/core/provider/VanityPathUriProviderTest.java
+++ b/core/src/test/java/org/cru/contentscoring/core/provider/VanityPathUriProviderTest.java
@@ -5,6 +5,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.cru.contentscoring.core.util.SystemUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -17,6 +18,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,9 +27,11 @@ public class VanityPathUriProviderTest {
     private ResourceResolver resourceResolver;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         resourceResolver = mock(ResourceResolver.class);
-        vanityPathUriProvider = new VanityPathUriProvider("local");
+        SystemUtils mockSystemUtils = mock(SystemUtils.class);
+        when(mockSystemUtils.getResourceResolver(anyString())).thenReturn(resourceResolver);
+        vanityPathUriProvider = new VanityPathUriProvider("local", mockSystemUtils);
         mockSlingMaps();
     }
 

--- a/core/src/test/java/org/cru/contentscoring/core/provider/VanityPathUriProviderTest.java
+++ b/core/src/test/java/org/cru/contentscoring/core/provider/VanityPathUriProviderTest.java
@@ -5,7 +5,6 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
-import org.cru.contentscoring.core.util.SystemUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -18,7 +17,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,11 +25,9 @@ public class VanityPathUriProviderTest {
     private ResourceResolver resourceResolver;
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
         resourceResolver = mock(ResourceResolver.class);
-        SystemUtils mockSystemUtils = mock(SystemUtils.class);
-        when(mockSystemUtils.getResourceResolver(anyString())).thenReturn(resourceResolver);
-        vanityPathUriProvider = new VanityPathUriProvider("local", mockSystemUtils);
+        vanityPathUriProvider = new VanityPathUriProvider("local");
         mockSlingMaps();
     }
 

--- a/core/src/test/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServletTest.java
+++ b/core/src/test/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServletTest.java
@@ -9,6 +9,7 @@ import org.apache.sling.api.resource.external.URIProvider;
 import org.apache.sling.api.resource.external.URIProvider.Scope;
 import org.apache.sling.api.resource.external.URIProvider.Operation;
 import org.cru.contentscoring.core.provider.VanityPathUriProvider;
+import org.cru.contentscoring.core.util.SystemUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -20,6 +21,7 @@ import java.net.URI;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,10 +35,14 @@ public class ResourceUrlMapperServletTest {
     private ResourceResolver resourceResolver;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         resourceResolver = mock(ResourceResolver.class);
         servlet.absolutePathUriProvider = mock(URIProvider.class);
         servlet.vanityPathUriProvider = mock(VanityPathUriProvider.class);
+
+        SystemUtils mockSystemUtils = mock(SystemUtils.class);
+        when(mockSystemUtils.getResourceResolver(anyString())).thenReturn(resourceResolver);
+        servlet.systemUtils = mockSystemUtils;
     }
 
     @Test

--- a/core/src/test/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServletTest.java
+++ b/core/src/test/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServletTest.java
@@ -29,7 +29,7 @@ public class ResourceUrlMapperServletTest {
     private static final String BASE_URL = "http://test.com";
     private static final String HTML_EXTENSION = ".html";
 
-    private ResourceUrlMapperServlet servlet = new ResourceUrlMapperServlet();
+    private final ResourceUrlMapperServlet servlet = new ResourceUrlMapperServlet();
     private ResourceResolver resourceResolver;
 
     @Before
@@ -127,7 +127,7 @@ public class ResourceUrlMapperServletTest {
         assertThat(json.contains(BASE_URL + vanityPath), is(equalTo(true)));
     }
 
-    private class StringParameter implements RequestParameter {
+    private static class StringParameter implements RequestParameter {
         String name;
         String value;
 

--- a/core/src/test/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServletTest.java
+++ b/core/src/test/java/org/cru/contentscoring/core/servlets/ResourceUrlMapperServletTest.java
@@ -5,9 +5,7 @@ import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestParameter;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.external.URIProvider;
-import org.apache.sling.api.resource.external.URIProvider.Scope;
-import org.apache.sling.api.resource.external.URIProvider.Operation;
+import org.cru.contentscoring.core.provider.AbsolutePathUriProvider;
 import org.cru.contentscoring.core.provider.VanityPathUriProvider;
 import org.cru.contentscoring.core.util.SystemUtils;
 import org.junit.Before;
@@ -37,7 +35,7 @@ public class ResourceUrlMapperServletTest {
     @Before
     public void setup() throws Exception {
         resourceResolver = mock(ResourceResolver.class);
-        servlet.absolutePathUriProvider = mock(URIProvider.class);
+        servlet.absolutePathUriProvider = mock(AbsolutePathUriProvider.class);
         servlet.vanityPathUriProvider = mock(VanityPathUriProvider.class);
 
         SystemUtils mockSystemUtils = mock(SystemUtils.class);
@@ -76,7 +74,7 @@ public class ResourceUrlMapperServletTest {
         Resource resource = mock(Resource.class);
         when(resourceResolver.getResource(absolutePath)).thenReturn(resource);
 
-        when(servlet.absolutePathUriProvider.toURI(resource, Scope.EXTERNAL, Operation.READ))
+        when(servlet.absolutePathUriProvider.toURI(resource, resourceResolver))
             .thenReturn(new URI(BASE_URL + absolutePath + HTML_EXTENSION));
 
         SlingHttpServletResponse response = mock(SlingHttpServletResponse.class);
@@ -109,7 +107,7 @@ public class ResourceUrlMapperServletTest {
         when(resourceResolver.getResource(absolutePath)).thenReturn(resource);
         when(resourceResolver.resolve(vanityPath)).thenReturn(resource);
 
-        when(servlet.absolutePathUriProvider.toURI(resource, Scope.EXTERNAL, Operation.READ))
+        when(servlet.absolutePathUriProvider.toURI(resource, resourceResolver))
             .thenReturn(new URI(BASE_URL + absolutePath + HTML_EXTENSION));
         when(servlet.vanityPathUriProvider.toURI(vanityPath, resourceResolver))
             .thenReturn(new URI(BASE_URL + vanityPath));


### PR DESCRIPTION
When we made the anonymous user no longer have access to `/etc/map.publish.<env>` this sync broke. This PR uses a system user already set up for this app to do the sling map lookup instead.