### PR TITLE
Turn off sync to API

### DIFF
--- a/core/src/main/java/org/cru/contentscoring/core/listeners/IndexerJobConsumer.java
+++ b/core/src/main/java/org/cru/contentscoring/core/listeners/IndexerJobConsumer.java
@@ -9,7 +9,7 @@ import org.apache.sling.event.jobs.consumer.JobConsumer;
 import org.apache.sling.settings.SlingSettingsService;
 import org.cru.commons.event.service.impl.ReplicationListenerOnPublishServiceImpl;
 import org.cru.contentscoring.core.service.ContentScoreUpdateService;
-import org.osgi.service.component.annotations.Component;
+//import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
@@ -20,11 +20,11 @@ import com.day.cq.replication.ReplicationActionType;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 
-@Component(
-    service = JobConsumer.class,
-    immediate = true,
-    property = {
-        JobConsumer.PROPERTY_TOPICS + "=" + ReplicationListenerOnPublishServiceImpl.SCORING_JOB_NAME})
+//@Component(
+//    service = JobConsumer.class,
+//    immediate = true,
+//    property = {
+//        JobConsumer.PROPERTY_TOPICS + "=" + ReplicationListenerOnPublishServiceImpl.SCORING_JOB_NAME})
 public class IndexerJobConsumer implements JobConsumer {
    
     private static final Logger LOG = LoggerFactory.getLogger(IndexerJobConsumer.class);

--- a/core/src/main/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImpl.java
+++ b/core/src/main/java/org/cru/contentscoring/core/service/impl/ContentScoreUpdateServiceImpl.java
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
-@Component(service = ContentScoreUpdateService.class, configurationPolicy = ConfigurationPolicy.REQUIRE)
+//@Component(service = ContentScoreUpdateService.class, configurationPolicy = ConfigurationPolicy.REQUIRE)
 @Designate(ocd = ContentScoreUpdateServiceImpl.Config.class)
 public class ContentScoreUpdateServiceImpl implements ContentScoreUpdateService {
 


### PR DESCRIPTION
We will likely be turning of the content scoring API until we have a replacement for Snowplow, so this will stop sending data there.